### PR TITLE
Add casts and conversions

### DIFF
--- a/lib/vapor/config.ex
+++ b/lib/vapor/config.ex
@@ -10,23 +10,83 @@ defmodule Vapor.Config do
         GenServer.call(__MODULE__, {:set, key, value})
       end
 
-      def get(key, as: type) when is_binary(key) and is_atom(type) do
-        get!(key, as: type)
-      rescue
-        Vapor.NotFoundError ->
-          nil
-      end
-
-      def get!(key, as: type) when is_binary(key) and is_atom(type) do
+      def get(key, as: type) when is_binary(key) do
         case :ets.lookup(__MODULE__, key) do
           [] ->
-            raise Vapor.NotFoundError, key
+            {:error, Vapor.NotFoundError}
 
           [{^key, value}] ->
-            value
+            Vapor.Config.Converter.apply(value, type)
+        end
+      end
+
+      def get!(key, as: type) when is_binary(key) do
+        case get(key, as: type) do
+          {:ok, val} ->
+            val
+
+          {:error, error} ->
+            raise error, {key, type}
         end
       end
     end
+  end
+
+  defmodule Converter do
+    @moduledoc """
+               Applies conversions to values. This module is intended to be hidden from
+               the end user.
+               """ && false
+
+    def apply(value, type) when is_atom(type) do
+      case type do
+        :string ->
+          {:ok, value}
+
+        :int ->
+          to_int(value)
+
+        :float ->
+          to_float(value)
+
+        :bool ->
+          to_bool(value)
+      end
+    end
+
+    def apply(value, type) when is_function(type, 1) do
+      case type.(value) do
+        {:ok, converted} ->
+          {:ok, converted}
+
+        {:error, _} ->
+          {:error, Vapor.ConversionError}
+      end
+    end
+
+    defp to_int(value) do
+      case Integer.parse(value) do
+        :error ->
+          {:error, Vapor.ConversionError}
+
+        {int, _} ->
+          {:ok, int}
+      end
+    end
+
+    defp to_float(value) do
+      case Float.parse(value) do
+        :error ->
+          {:error, Vapor.ConversionError}
+
+        {num, _} ->
+          {:ok, num}
+      end
+    end
+
+    defp to_bool("true"), do: {:ok, true}
+    defp to_bool("false"), do: {:ok, false}
+    defp to_bool(_), do: {:error, Vapor.ConversionError}
   end
 
   @doc """

--- a/lib/vapor/exceptions.ex
+++ b/lib/vapor/exceptions.ex
@@ -2,8 +2,23 @@ defmodule Vapor.NotFoundError do
   defexception [:message]
 
   @impl true
-  def exception(key) do
+  def exception({key, _}) do
     msg = "did not find a value for key: #{inspect(key)}"
+    %__MODULE__{message: msg}
+  end
+end
+
+defmodule Vapor.ConversionError do
+  defexception [:message]
+
+  @impl true
+  def exception({key, type}) when is_atom(type) do
+    msg = "could not convert #{key} to type: #{type}"
+    %__MODULE__{message: msg}
+  end
+
+  def exception({key, type}) when is_function(type) do
+    msg = "could not convert #{key} with custom type"
     %__MODULE__{message: msg}
   end
 end

--- a/test/vapor/config_test.exs
+++ b/test/vapor/config_test.exs
@@ -1,0 +1,69 @@
+defmodule Vapor.ConfigTest do
+  use ExUnit.Case, async: true
+
+  defmodule TestConfig do
+    use Vapor.Config
+
+    def start_link() do
+      Vapor.start_link(__MODULE__, Vapor.Config.default(), name: __MODULE__)
+    end
+  end
+
+  describe "get/2" do
+    test "supports common transforms" do
+      TestConfig.start_link()
+
+      TestConfig.set("string", "string")
+      TestConfig.set("int", "42")
+      TestConfig.set("float", "3.2")
+      TestConfig.set("true", "true")
+      TestConfig.set("false", "false")
+
+      assert TestConfig.get("string", as: :string) == {:ok, "string"}
+      assert TestConfig.get("int", as: :int) == {:ok, 42}
+      assert TestConfig.get("float", as: :float) == {:ok, 3.2}
+      assert TestConfig.get("true", as: :bool) == {:ok, true}
+      assert TestConfig.get("false", as: :bool) == {:ok, false}
+    end
+
+    test "returns errors if conversions fail" do
+      TestConfig.start_link()
+
+      TestConfig.set("string", "string")
+
+      assert TestConfig.get("string", as: :int) == {:error, Vapor.ConversionError}
+      assert TestConfig.get("string", as: :float) == {:error, Vapor.ConversionError}
+      assert TestConfig.get("string", as: :bool) == {:error, Vapor.ConversionError}
+
+      assert_raise Vapor.ConversionError, fn ->
+        TestConfig.get!("string", as: :int)
+      end
+
+      assert_raise Vapor.ConversionError, fn ->
+        TestConfig.get!("string", as: :float)
+      end
+
+      assert_raise Vapor.ConversionError, fn ->
+        TestConfig.get!("string", as: :bool)
+      end
+    end
+
+    test "allows custom conversions" do
+      TestConfig.start_link()
+
+      TestConfig.set("string", "string")
+
+      assert TestConfig.get!("string", as: fn "string" -> {:ok, "bar"} end) == "bar"
+
+      assert TestConfig.get("string",
+               as: fn "string" ->
+                 {:error, nil}
+               end
+             ) == {:error, Vapor.ConversionError}
+
+      assert_raise Vapor.ConversionError, fn ->
+        TestConfig.get!("string", as: fn "string" -> {:error, nil} end)
+      end
+    end
+  end
+end

--- a/test/vapor_test.exs
+++ b/test/vapor_test.exs
@@ -1,5 +1,5 @@
 defmodule VaporTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   doctest Vapor
 
   alias Vapor.Config
@@ -21,7 +21,7 @@ defmodule VaporTest do
       TestConfig.set("foo", "foo")
 
       assert TestConfig.get!("foo", as: :string) == "foo"
-      assert TestConfig.get("blank", as: :string) == nil
+      assert TestConfig.get("blank", as: :string) == {:error, Vapor.NotFoundError}
 
       assert_raise Vapor.NotFoundError, fn ->
         TestConfig.get!("blank", as: :string)
@@ -38,8 +38,8 @@ defmodule VaporTest do
 
       TestConfig.start_link(config)
 
-      assert TestConfig.get("foo", as: :string) == "foo"
-      assert TestConfig.get("bar", as: :string) == "bar"
+      assert TestConfig.get!("foo", as: :string) == "foo"
+      assert TestConfig.get!("bar", as: :string) == "bar"
     end
 
     test "can be stacked" do
@@ -53,9 +53,9 @@ defmodule VaporTest do
 
       TestConfig.start_link(config)
 
-      assert TestConfig.get("foo", as: :string) == "file foo"
-      assert TestConfig.get("bar", as: :string) == "env bar"
-      assert TestConfig.get("baz", as: :string) == "file baz"
+      assert TestConfig.get!("foo", as: :string) == "file foo"
+      assert TestConfig.get!("bar", as: :string) == "env bar"
+      assert TestConfig.get!("baz", as: :string) == "file baz"
     end
 
     test "manual config always takes precedence" do
@@ -72,9 +72,9 @@ defmodule VaporTest do
       TestConfig.set("foo", "manual foo")
       TestConfig.set("bar", "manual bar")
 
-      assert TestConfig.get("foo", as: :string) == "manual foo"
-      assert TestConfig.get("bar", as: :string) == "manual bar"
-      assert TestConfig.get("baz", as: :string) == "file baz"
+      assert TestConfig.get!("foo", as: :string) == "manual foo"
+      assert TestConfig.get!("bar", as: :string) == "manual bar"
+      assert TestConfig.get!("baz", as: :string) == "file baz"
     end
   end
 end


### PR DESCRIPTION
This PR introduces additional cast options and allows the user to specify their own cast if need be. In order to implement this I've updated the semantics of `get/2` and `get!/2`. I had mixed feelings about these changes but I think the new semantics provide the best tradeoffs.

`get/2` now returns `{:ok, term()} | {:error, Error}`. `get!/2` will raise errors if values can't be found or if they don't convert correctly. This may not be exactly the semantics we want long term but I think they're good enough for now.