### PR TITLE
normalize keys to lists

### DIFF
--- a/lib/vapor/config.ex
+++ b/lib/vapor/config.ex
@@ -19,10 +19,18 @@ defmodule Vapor.Config do
       end
 
       def set(key, value) when is_binary(key) do
+        set([key], value)
+      end
+
+      def set(key, value) when is_list(key) do
         GenServer.call(__MODULE__, {:set, key, value})
       end
 
       def get(key, as: type) when is_binary(key) do
+        get([key], as: type)
+      end
+
+      def get(key, as: type) when is_list(key) do
         case :ets.lookup(__MODULE__, key) do
           [] ->
             {:error, Vapor.NotFoundError}
@@ -33,6 +41,10 @@ defmodule Vapor.Config do
       end
 
       def get!(key, as: type) when is_binary(key) do
+        get!([key], as: type)
+      end
+
+      def get!(key, as: type) when is_list(key) do
         case get(key, as: type) do
           {:ok, val} ->
             val

--- a/lib/vapor/config/env.ex
+++ b/lib/vapor/config/env.ex
@@ -79,6 +79,7 @@ defmodule Vapor.Config.Env do
       str
       |> String.replace_leading(prefix, "")
       |> String.downcase()
+      |> String.split("_")
     end
 
     defp matches_prefix?({k, _v}, prefix) do

--- a/test/support/settings.json
+++ b/test/support/settings.json
@@ -1,1 +1,1 @@
-{"foo": "file foo", "baz": "file baz"}
+{"foo":"file foo", "baz":"file baz", "biz": {"boz": "file biz boz"}}

--- a/test/support/settings.toml
+++ b/test/support/settings.toml
@@ -1,2 +1,3 @@
 foo = "foo toml"
 bar = "bar toml"
+biz.boz = "biz boz toml"

--- a/test/support/settings.yaml
+++ b/test/support/settings.yaml
@@ -1,2 +1,4 @@
 foo: "foo yaml"
 bar: "bar yaml"
+biz:
+  boz: "biz boz yaml"

--- a/test/vapor/config/env_test.exs
+++ b/test/vapor/config/env_test.exs
@@ -17,8 +17,15 @@ defmodule Vapor.Config.EnvTest do
 
     plan = Env.with_prefix("APP")
     {:ok, envs} = Vapor.Provider.load(plan)
-    assert envs["foo"] == "env foo"
-    assert envs["bar"] == "env bar"
+    assert envs[["foo"]] == "env foo"
+    assert envs[["bar"]] == "env bar"
+  end
+
+  test "with_prefix/1 splits on _ into list" do
+    System.put_env("APP_FOO_BAR", "env foo bar")
+    plan = Env.with_prefix("APP")
+    {:ok, envs} = Vapor.Provider.load(plan)
+    assert envs[["foo", "bar"]] == "env foo bar"
   end
 
   describe "with_bindings/1" do
@@ -26,11 +33,13 @@ defmodule Vapor.Config.EnvTest do
       System.put_env("FOO", "env foo")
       System.put_env("BAR", "env bar")
 
-      plan = Env.with_bindings([
-        foo: "FOO",
-        bar: "BAR",
-        baz: "BAZ"
-      ])
+      plan =
+        Env.with_bindings(
+          foo: "FOO",
+          bar: "BAR",
+          baz: "BAZ"
+        )
+
       assert {:error, _} = Vapor.Provider.load(plan)
 
       System.put_env("BAZ", "env baz")

--- a/test/vapor/config_test.exs
+++ b/test/vapor/config_test.exs
@@ -55,7 +55,8 @@ defmodule Vapor.ConfigTest do
 
       assert TestConfig.get!("string", as: fn "string" -> {:ok, "bar"} end) == "bar"
 
-      assert TestConfig.get("string",
+      assert TestConfig.get(
+               "string",
                as: fn "string" ->
                  {:error, nil}
                end

--- a/test/vapor_test.exs
+++ b/test/vapor_test.exs
@@ -58,6 +58,19 @@ defmodule VaporTest do
       assert TestConfig.get!("baz", as: :string) == "file baz"
     end
 
+    test "path lists can be stacked" do
+      config =
+        Config.default()
+        |> Config.merge(Config.Env.with_prefix("APP"))
+        |> Config.merge(Config.File.with_name("test/support/settings.json"))
+
+      System.put_env("APP_BIZ_BOZ", "env biz boz")
+
+      TestConfig.start_link(config)
+
+      assert TestConfig.get!(["biz", "boz"], as: :string) == "file biz boz"
+    end
+
     test "manual config always takes precedence" do
       config =
         Config.default()
@@ -86,6 +99,7 @@ defmodule VaporTest do
 
       assert(TestConfig.get!("foo", as: :string) == "foo toml")
       assert(TestConfig.get!("bar", as: :string) == "bar toml")
+      assert(TestConfig.get!(["biz", "boz"], as: :string) == "biz boz toml")
     end
 
     test "reads config from yaml" do
@@ -97,6 +111,7 @@ defmodule VaporTest do
 
       assert(TestConfig.get!("foo", as: :string) == "foo yaml")
       assert(TestConfig.get!("bar", as: :string) == "bar yaml")
+      assert(TestConfig.get!(["biz", "boz"], as: :string) == "biz boz yaml")
     end
   end
 end


### PR DESCRIPTION
Prior to this commit, Vapor did not support nested keys or structures,
which meant that all the configs would have to be specified at the top
level. For example:

```
{
 "database_hostname":"localhost,
 "database_port":5432,
 "database_username":"postgres",
 "database_password":"postgres",
 "database_dbname:"my_app"
}
```
This commit allows for nested configurations coming in and will flatten
then to a key-path list. The above example can now be specified as:
```
{
  "database": {
    "hostname":"localhost",
    "port":5432,
    "username":"postgres",
    "password":"postgres",
    "dbname":"my_app"
  }
}
```
If, for example, we're interested in the database port and we have the
configuration both in the file and the corresponding environment
variable of "APP_DATABASE_PORT", we can access the appropriate value
using `["database", "port"]`.

Closes #14.