### PR TITLE
Add better stacking of configuration

### DIFF
--- a/lib/vapor/config.ex
+++ b/lib/vapor/config.ex
@@ -1,10 +1,13 @@
 defmodule Vapor.Config do
-  alias Vapor.Config
-
   @moduledoc """
   This module provides conveniences for creating dynamic configuration layouts
   and overlays.
   """
+
+  alias Vapor.{
+    Config,
+    Plan,
+  }
 
   defmacro __using__(_opts) do
     quote do
@@ -117,14 +120,14 @@ defmodule Vapor.Config do
   Creates an initial configuration.
   """
   def default do
-    []
+    Plan.new()
   end
 
   @doc """
   Merges an existing configuration plan with a new configuration plan.
   Plans are stacked and applied in the order that they are merged.
   """
-  def merge(existing_plan, plan) do
-    existing_plan ++ [plan]
+  def merge(existing_plan, provider) do
+    Plan.merge(existing_plan, provider)
   end
 end

--- a/lib/vapor/configuration.ex
+++ b/lib/vapor/configuration.ex
@@ -1,0 +1,50 @@
+defmodule Vapor.Configuration do
+  defstruct layers: %{}, versions: []
+
+  def keys(%{layers: layers}) do
+    layers
+    |> Enum.sort(fn {a, _}, {b, _} -> a < b end) # Ensure proper sorting
+    |> Enum.map(fn {_, map} -> pathify_keys(map) end)
+    |> Enum.reduce(%{}, fn keys, acc -> Map.merge(acc, keys) end)
+  end
+
+  def load(plan) when is_map(plan) do
+    results =
+      plan
+      |> Enum.map(fn {key, provider} -> {key, Vapor.Provider.load(provider)} end)
+
+    errors =
+      results
+      |> Enum.filter(fn {_, {result, _}} -> result == :error end)
+
+    if Enum.any?(errors) do
+      {:error, errors}
+    else
+      layers =
+        results
+        |> Enum.map(fn {key, {:ok, v}} -> {key, v} end)
+        |> Enum.into(%{})
+
+      {:ok, %__MODULE__{layers: layers}}
+    end
+  end
+
+  defp pathify_keys(map) when is_map(map) do
+    map
+    |> pathify_keys([], [])
+    |> Enum.into(%{})
+  end
+
+  defp pathify_keys(map, path_so_far, completed_keys) do
+    Enum.reduce(map, completed_keys, fn
+      {k, v}, acc when is_map(v) ->
+        pathify_keys(v, [k | path_so_far], acc)
+
+      {k, v}, acc when is_list(k) ->
+        [{k, v} | acc]
+
+      {k, v}, acc ->
+        [{Enum.reverse([k | path_so_far]), v} | acc]
+    end)
+  end
+end

--- a/lib/vapor/plan.ex
+++ b/lib/vapor/plan.ex
@@ -5,10 +5,10 @@ defmodule Vapor.Plan do
 
   def merge(plan, provider) do
     plan
-    |> Map.put(next_key(plan), provider)
+    |> Map.put(next_layer(plan), provider)
   end
 
-  defp next_key(plan) do
+  defp next_layer(plan) do
     if Enum.empty?(Map.keys(plan)) do
       0
     else

--- a/lib/vapor/plan.ex
+++ b/lib/vapor/plan.ex
@@ -1,0 +1,22 @@
+defmodule Vapor.Plan do
+  def new do
+    %{}
+  end
+
+  def merge(plan, provider) do
+    plan
+    |> Map.put(next_key(plan), provider)
+  end
+
+  defp next_key(plan) do
+    if Enum.empty?(Map.keys(plan)) do
+      0
+    else
+      plan
+      |> Map.keys
+      |> Enum.max()
+      |> Kernel.+(1)
+    end
+  end
+end
+

--- a/lib/vapor/store.ex
+++ b/lib/vapor/store.ex
@@ -1,23 +1,36 @@
 defmodule Vapor.Store do
-  use GenServer
-
   @moduledoc """
-    Module that loads config
-    Attempts to load the config 10 times before returning :error
+  Module that loads config
+  Attempts to load the config 10 times before returning :error
   """
 
-  def start_link({module, plans}) do
-    GenServer.start_link(__MODULE__, {module, plans}, name: module)
+  use GenServer
+
+  alias Vapor.Configuration
+
+  def start_link({module, plan}) do
+    GenServer.start_link(__MODULE__, {module, plan}, name: module)
   end
 
-  def init({module, plans}) do
-    ^module = :ets.new(module, [:set, :protected, :named_table])
+  def init({module, plan}) do
+    table_opts = [
+      :set,
+      :protected,
+      :named_table,
+      read_concurrency: true,
+    ]
 
-    case load_config(module, plans) do
-      :ok ->
-        {:ok, %{plans: plans, table: module}}
+    ^module = :ets.new(module, table_opts)
 
-      :error ->
+    case Configuration.load(plan) do
+      {:ok, config} ->
+        config
+        |> Configuration.keys
+        |> Enum.each(fn key -> :ets.insert(module, key) end)
+
+        {:ok, %{config: config, table: module}}
+
+      {:error, _} ->
         {:stop, :could_not_load_config}
     end
   end
@@ -26,44 +39,5 @@ defmodule Vapor.Store do
     :ets.insert(tab, {key, value})
 
     {:reply, {:ok, value}, state}
-  end
-
-  defp pathify_keys(map) when is_map(map) do
-    map
-    |> pathify_keys([], [])
-    |> Enum.into(%{})
-  end
-
-  defp pathify_keys(map, path_so_far, completed_keys) do
-    Enum.reduce(map, completed_keys, fn
-      {k, v}, acc when is_map(v) ->
-        pathify_keys(v, [k | path_so_far], acc)
-
-      {k, v}, acc when is_list(k) ->
-        [{k, v} | acc]
-
-      {k, v}, acc ->
-        [{Enum.reverse([k | path_so_far]), v} | acc]
-    end)
-  end
-
-  defp load_config(table, plans, retry_count \\ 0)
-  defp load_config(_table, [], _), do: :ok
-  defp load_config(_table, _, 10), do: :error
-
-  defp load_config(table, [plan | rest], retry_count) do
-    case Vapor.Provider.load(plan) do
-      {:ok, configs} ->
-        configs
-        |> pathify_keys
-        |> Enum.each(fn k_v ->
-          :ets.insert(table, k_v)
-        end)
-
-        load_config(table, rest, 0)
-
-      {:error, _e} ->
-        load_config(table, [plan | rest], retry_count + 1)
-    end
   end
 end


### PR DESCRIPTION
This PR provides proper support for layering configuration values and should make it easier to build out some important features such as watching and rollbacks in the future.

I've created a new Configuration struct and module to provide all of the layering functionality. I think this is a terrible name so we should probably change it. The main role of Configuration is to hold onto a list of values that have been resolved from whatever provider. It can collapse these values into a list of keys which can then be easily loaded into an ets table. It can also maintain previous versions. Currently the versions are unused and only there for demonstration purposes. I suspect that realistically we'll want to use some sort of circular buffer or other bounded data structure to hold versions.

I've also created a `Plan` module for building up these configuration plans. Personally I find this to be a very shallow module but for some reason I felt compelled to keep those things separate for now. If anyone has better ideas here I'm happy to hear them.

Let me know what you think. @jeffweiss I know that you had some thoughts on this as well so let me know if this jives well with what you've been playing around with.