### PR TITLE
Support watching sources.

### DIFF
--- a/lib/vapor.ex
+++ b/lib/vapor.ex
@@ -13,4 +13,8 @@ defmodule Vapor do
       raise Vapor.ConfigurationError, "must supply a `:name` argument"
     end
   end
+
+  def stop(name) do
+    Vapor.Store.Supervisor.stop(name)
+  end
 end

--- a/lib/vapor/config.ex
+++ b/lib/vapor/config.ex
@@ -1,10 +1,13 @@
 defmodule Vapor.Config do
-  alias Vapor.Config
-
   @moduledoc """
   This module provides conveniences for creating dynamic configuration layouts
   and overlays.
   """
+
+  alias Vapor.{
+    Config,
+    Plan,
+  }
 
   defmacro __using__(_opts) do
     quote do
@@ -117,14 +120,14 @@ defmodule Vapor.Config do
   Creates an initial configuration.
   """
   def default do
-    []
+    Plan.new()
   end
 
   @doc """
   Merges an existing configuration plan with a new configuration plan.
   Plans are stacked and applied in the order that they are merged.
   """
-  def merge(existing_plan, plan) do
-    existing_plan ++ [plan]
+  def merge(existing_plan, provider) do
+    Plan.merge(existing_plan, provider)
   end
 end

--- a/lib/vapor/config.ex
+++ b/lib/vapor/config.ex
@@ -130,4 +130,8 @@ defmodule Vapor.Config do
   def merge(existing_plan, provider) do
     Plan.merge(existing_plan, provider)
   end
+
+  def watch(plan, provider, opts \\ []) do
+    Plan.watch(plan, provider, opts)
+  end
 end

--- a/lib/vapor/configuration.ex
+++ b/lib/vapor/configuration.ex
@@ -1,36 +1,73 @@
 defmodule Vapor.Configuration do
+  @moduledoc """
+  Manages a layered set of configuration values.
+  """
+
   defstruct layers: %{overrides: %{}}, versions: []
 
+  @type t :: %__MODULE__{
+    layers: %{required(layer) => map()},
+    versions: [],
+  }
+
+  @typedoc """
+  The path to store the value at. Serves as a key.
+  """
+  @type path :: list(String.t)
+
+  @typedoc """
+  The action needed to achieve consistency with the desired configuration.
+  """
+  @type action :: {:upsert, path, term()}
+                | {:delete, path}
+
+  @type layer :: integer()
+               | :overrides
+
+  @doc """
+  Returns a new configuration with an initial set of layers and a list of
+  initial actions to run.
+  """
+  @spec new(%{}) :: {t(), list(action())}
   def new(layers) do
     # We're abusing term ordering here. The `:overrides` atom will always
     # be the highest precedence simply because its an atom
     configuration = %__MODULE__{layers: Map.merge(%{overrides: %{}}, layers)}
 
     actions =
-      configuration.layers
-      |> Enum.sort(fn {a, _}, {b, _} -> a < b end) # Ensure proper sorting
-      |> Enum.map(fn {_, map} -> pathify_keys(map) end)
-      |> Enum.reduce(%{}, fn paths, acc -> Map.merge(acc, paths) end)
+      configuration
+      |> flatten
       |> Enum.map(fn {path, value} -> {:upsert, path, value} end)
 
     {configuration, actions}
   end
 
+  @doc """
+  Overwrites a value at a given path. Overwrites always take precedence over
+  any other configuration values.
+  """
+  @spec set(t(), path(), term()) :: {t(), list(action)}
   def set(config, path, value) do
     overrides = config.layers.overrides
     update(config, :overrides, Map.put(overrides, path, value))
   end
 
+  @doc """
+  Updates a specific layer in the configuration.
+  """
+  @spec update(t(), layer(), map()) :: {t(), list(action)}
   def update(%{layers: ls}=config, layer, value) do
-    old_paths = keys(config)
+    old_paths = flatten(config)
     new_config = %{config | layers: Map.put(ls, layer, value)}
-    new_paths = keys(new_config)
+    new_paths = flatten(new_config)
     actions = diff(new_paths, old_paths)
 
     {new_config, actions}
   end
 
-  def diff(new_paths, old_paths) when is_map(new_paths) and is_map(old_paths) do
+  # Takes an old configuration and new configuration and returns a list of
+  # commands needed to convert the old config into the new config.
+  defp diff(new_paths, old_paths) when is_map(new_paths) and is_map(old_paths) do
     new_list =
       new_paths
       |> Enum.to_list
@@ -42,26 +79,27 @@ defmodule Vapor.Configuration do
     # This is expensive but it allows us to only diff the meaningful bits
     diff(new_list -- old_list, old_list -- new_list, [])
   end
-  def diff([], old_paths, acc) do
+
+  # If we're out of new paths then any remaining old paths are deletes.
+  defp diff([], old_paths, acc) do
     acc ++ Enum.map(old_paths, fn {path, _} -> {:delete, path} end)
   end
-  def diff(new_paths, [], acc) do
+
+  # If we're out of old paths then everything left is an upsert by default
+  defp diff(new_paths, [], acc) do
     acc ++ Enum.map(new_paths, fn {path, value} -> {:upsert, path, value} end)
   end
-  def diff([{path, value} | nps], old_paths, acc) do
+
+  # If we get here then we know that we need to do an upsert and remove any
+  # old configs with a matching path to our new config. Then we can keep
+  # recursing
+  defp diff([{path, value} | nps], old_paths, acc) do
     acc = [{:upsert, path, value} | acc]
-
-    case Enum.find_index(old_paths, fn {old_path, _} -> path == old_path end) do
-     nil ->
-        diff(nps, old_paths, acc)
-
-      # If we find an index then we need to remove it from the old list
-      index ->
-        diff(nps, List.delete_at(old_paths, index), acc)
-    end
+    old_paths = Enum.reject(old_paths, fn {old_path, _} -> path == old_path end)
+    diff(nps, old_paths, acc)
   end
 
-  defp keys(%{layers: layers}) do
+  defp flatten(%{layers: layers}) do
     layers
     |> Enum.sort(fn {a, _}, {b, _} -> a < b end) # Ensure proper sorting
     |> Enum.map(fn {_, map} -> pathify_keys(map) end)

--- a/lib/vapor/configuration.ex
+++ b/lib/vapor/configuration.ex
@@ -1,32 +1,71 @@
 defmodule Vapor.Configuration do
-  defstruct layers: %{}, versions: []
+  defstruct layers: %{overrides: %{}}, versions: []
 
-  def keys(%{layers: layers}) do
+  def new(layers) do
+    # We're abusing term ordering here. The `:overrides` atom will always
+    # be the highest precedence simply because its an atom
+    configuration = %__MODULE__{layers: Map.merge(%{overrides: %{}}, layers)}
+
+    actions =
+      configuration.layers
+      |> Enum.sort(fn {a, _}, {b, _} -> a < b end) # Ensure proper sorting
+      |> Enum.map(fn {_, map} -> pathify_keys(map) end)
+      |> Enum.reduce(%{}, fn paths, acc -> Map.merge(acc, paths) end)
+      |> Enum.map(fn {path, value} -> {:upsert, path, value} end)
+
+    {configuration, actions}
+  end
+
+  def set(config, path, value) do
+    overrides = config.layers.overrides
+    update(config, :overrides, Map.put(overrides, path, value))
+  end
+
+  def update(%{layers: ls}=config, layer, value) do
+    old_paths = keys(config)
+    new_config = %{config | layers: Map.put(ls, layer, value)}
+    new_paths = keys(new_config)
+    actions = diff(new_paths, old_paths)
+
+    {new_config, actions}
+  end
+
+  def diff(new_paths, old_paths) when is_map(new_paths) and is_map(old_paths) do
+    new_list =
+      new_paths
+      |> Enum.to_list
+
+    old_list =
+      old_paths
+      |> Enum.to_list
+
+    # This is expensive but it allows us to only diff the meaningful bits
+    diff(new_list -- old_list, old_list -- new_list, [])
+  end
+  def diff([], old_paths, acc) do
+    acc ++ Enum.map(old_paths, fn {path, _} -> {:delete, path} end)
+  end
+  def diff(new_paths, [], acc) do
+    acc ++ Enum.map(new_paths, fn {path, value} -> {:upsert, path, value} end)
+  end
+  def diff([{path, value} | nps], old_paths, acc) do
+    acc = [{:upsert, path, value} | acc]
+
+    case Enum.find_index(old_paths, fn {old_path, _} -> path == old_path end) do
+     nil ->
+        diff(nps, old_paths, acc)
+
+      # If we find an index then we need to remove it from the old list
+      index ->
+        diff(nps, List.delete_at(old_paths, index), acc)
+    end
+  end
+
+  defp keys(%{layers: layers}) do
     layers
     |> Enum.sort(fn {a, _}, {b, _} -> a < b end) # Ensure proper sorting
     |> Enum.map(fn {_, map} -> pathify_keys(map) end)
     |> Enum.reduce(%{}, fn keys, acc -> Map.merge(acc, keys) end)
-  end
-
-  def load(plan) when is_map(plan) do
-    results =
-      plan
-      |> Enum.map(fn {key, provider} -> {key, Vapor.Provider.load(provider)} end)
-
-    errors =
-      results
-      |> Enum.filter(fn {_, {result, _}} -> result == :error end)
-
-    if Enum.any?(errors) do
-      {:error, errors}
-    else
-      layers =
-        results
-        |> Enum.map(fn {key, {:ok, v}} -> {key, v} end)
-        |> Enum.into(%{})
-
-      {:ok, %__MODULE__{layers: layers}}
-    end
   end
 
   defp pathify_keys(map) when is_map(map) do

--- a/lib/vapor/configuration.ex
+++ b/lib/vapor/configuration.ex
@@ -1,0 +1,50 @@
+defmodule Vapor.Configuration do
+  defstruct layers: %{}, versions: []
+
+  def keys(%{layers: layers}) do
+    layers
+    |> Enum.sort(fn {a, _}, {b, _} -> a < b end) # Ensure proper sorting
+    |> Enum.map(fn {_, map} -> pathify_keys(map) end)
+    |> Enum.reduce(%{}, fn keys, acc -> Map.merge(acc, keys) end)
+  end
+
+  def load(plan) when is_map(plan) do
+    results =
+      plan
+      |> Enum.map(fn {key, provider} -> {key, Vapor.Provider.load(provider)} end)
+
+    errors =
+      results
+      |> Enum.filter(fn {_, {result, _}} -> result == :error end)
+
+    if Enum.any?(errors) do
+      {:error, errors}
+    else
+      layers =
+        results
+        |> Enum.map(fn {key, {:ok, v}} -> {key, v} end)
+        |> Enum.into(%{})
+
+      {:ok, %__MODULE__{layers: layers}}
+    end
+  end
+
+  defp pathify_keys(map) when is_map(map) do
+    map
+    |> pathify_keys([], [])
+    |> Enum.into(%{})
+  end
+
+  defp pathify_keys(map, path_so_far, completed_keys) do
+    Enum.reduce(map, completed_keys, fn
+      {k, v}, acc when is_map(v) ->
+        pathify_keys(v, [k | path_so_far], acc)
+
+      {k, v}, acc when is_list(k) ->
+        [{k, v} | acc]
+
+      {k, v}, acc ->
+        [{Enum.reverse([k | path_so_far]), v} | acc]
+    end)
+  end
+end

--- a/lib/vapor/plan.ex
+++ b/lib/vapor/plan.ex
@@ -1,0 +1,22 @@
+defmodule Vapor.Plan do
+  def new do
+    %{}
+  end
+
+  def merge(plan, provider) do
+    plan
+    |> Map.put(next_layer(plan), provider)
+  end
+
+  defp next_layer(plan) do
+    if Enum.empty?(Map.keys(plan)) do
+      0
+    else
+      plan
+      |> Map.keys
+      |> Enum.max()
+      |> Kernel.+(1)
+    end
+  end
+end
+

--- a/lib/vapor/plan.ex
+++ b/lib/vapor/plan.ex
@@ -1,11 +1,51 @@
 defmodule Vapor.Plan do
+
+  @default_watch_opts [
+    refresh_interval: 30_000
+  ]
+
   def new do
     %{}
   end
 
   def merge(plan, provider) do
     plan
-    |> Map.put(next_layer(plan), provider)
+    |> Map.put(next_layer(plan), %{watch: false, provider: provider})
+  end
+
+  def watch(plan, provider, opts \\ []) do
+    watch_opts =
+      @default_watch_opts
+      |> Keyword.merge(opts)
+
+    plan
+    |> Map.put(next_layer(plan), %{watch: true, provider: provider, opts: watch_opts})
+  end
+
+  def load(plans) when is_map(plans) do
+    results =
+      plans
+      |> Enum.map(fn {key, plan} -> {key, Vapor.Provider.load(plan.provider)} end)
+
+    errors =
+      results
+      |> Enum.filter(fn {_, {result, _}} -> result == :error end)
+
+    if Enum.any?(errors) do
+      {:error, errors}
+    else
+      layers =
+        results
+        |> Enum.map(fn {key, {:ok, v}} -> {key, v} end)
+        |> Enum.into(%{})
+
+      {:ok, layers}
+    end
+  end
+
+  def watches(plan) do
+    plan
+    |> Enum.filter(fn {_, p} -> p.watch end)
   end
 
   defp next_layer(plan) do

--- a/lib/vapor/plan.ex
+++ b/lib/vapor/plan.ex
@@ -1,7 +1,7 @@
 defmodule Vapor.Plan do
 
   @default_watch_opts [
-    refresh_interval: 30_000
+    refresh_interval: 30_000,
   ]
 
   def new do

--- a/lib/vapor/store.ex
+++ b/lib/vapor/store.ex
@@ -6,13 +6,21 @@ defmodule Vapor.Store do
 
   use GenServer
 
-  alias Vapor.Configuration
+  alias Vapor.{
+    Configuration,
+    Plan,
+    Watch
+  }
 
-  def start_link({module, plan}) do
-    GenServer.start_link(__MODULE__, {module, plan}, name: module)
+  def start_link({module, plans}) do
+    GenServer.start_link(__MODULE__, {module, plans}, name: module)
   end
 
-  def init({module, plan}) do
+  def update(store, layer, new_config) do
+    GenServer.call(store, {:update, layer, new_config})
+  end
+
+  def init({module, plans}) do
     table_opts = [
       :set,
       :protected,
@@ -22,11 +30,14 @@ defmodule Vapor.Store do
 
     ^module = :ets.new(module, table_opts)
 
-    case Configuration.load(plan) do
-      {:ok, config} ->
-        config
-        |> Configuration.keys
-        |> Enum.each(fn key -> :ets.insert(module, key) end)
+    case Plan.load(plans) do
+      {:ok, layers} ->
+        {config, actions} = Configuration.new(layers)
+        process_actions(actions, module)
+
+        plans
+        |> Plan.watches
+        |> Enum.each(fn {layer, plan} -> start_watch(layer, plan, module) end)
 
         {:ok, %{config: config, table: module}}
 
@@ -35,9 +46,36 @@ defmodule Vapor.Store do
     end
   end
 
-  def handle_call({:set, key, value}, _from, %{table: tab} = state) do
-    :ets.insert(tab, {key, value})
+  def handle_call({:update, layer, new_values}, _, %{config: config}=state) do
+    {new_config, actions} = Configuration.update(config, layer, new_values)
+    process_actions(actions, state.table)
 
-    {:reply, {:ok, value}, state}
+    {:reply, :ok, %{state | config: new_config}}
+  end
+
+  def handle_call({:set, key, value}, _from, %{config: config}=state) do
+    {new_config, actions} = Configuration.set(config, key, value)
+    process_actions(actions, state.table)
+
+    {:reply, {:ok, value}, %{state | config: new_config}}
+  end
+
+  defp process_actions(actions, table) do
+    actions
+    |> Enum.each(fn action -> process_action(action, table) end)
+  end
+
+  defp process_action(action, table) do
+    case action do
+      {:upsert, key, value} ->
+        :ets.insert(table, {key, value})
+
+      {:delete, key} ->
+        :ets.delete(table, key)
+    end
+  end
+
+  defp start_watch(layer, plan, module) do
+    Watch.Supervisor.start_child(module, %{layer: layer, plan: plan, store: module})
   end
 end

--- a/lib/vapor/store.ex
+++ b/lib/vapor/store.ex
@@ -1,23 +1,36 @@
 defmodule Vapor.Store do
-  use GenServer
-
   @moduledoc """
-    Module that loads config
-    Attempts to load the config 10 times before returning :error
+  Module that loads config
+  Attempts to load the config 10 times before returning :error
   """
 
-  def start_link({module, plans}) do
-    GenServer.start_link(__MODULE__, {module, plans}, name: module)
+  use GenServer
+
+  alias Vapor.Configuration
+
+  def start_link({module, plan}) do
+    GenServer.start_link(__MODULE__, {module, plan}, name: module)
   end
 
-  def init({module, plans}) do
-    ^module = :ets.new(module, [:set, :protected, :named_table])
+  def init({module, plan}) do
+    table_opts = [
+      :set,
+      :protected,
+      :named_table,
+      read_concurrency: true,
+    ]
 
-    case load_config(module, plans) do
-      :ok ->
-        {:ok, %{plans: plans, table: module}}
+    ^module = :ets.new(module, table_opts)
 
-      :error ->
+    case Configuration.load(plan) do
+      {:ok, config} ->
+        config
+        |> Configuration.keys
+        |> Enum.each(fn key -> :ets.insert(module, key) end)
+
+        {:ok, %{config: config, table: module}}
+
+      {:error, _} ->
         {:stop, :could_not_load_config}
     end
   end
@@ -26,44 +39,5 @@ defmodule Vapor.Store do
     :ets.insert(tab, {key, value})
 
     {:reply, {:ok, value}, state}
-  end
-
-  defp pathify_keys(map) when is_map(map) do
-    map
-    |> pathify_keys([], [])
-    |> Enum.into(%{})
-  end
-
-  defp pathify_keys(map, path_so_far, completed_keys) do
-    Enum.reduce(map, completed_keys, fn
-      {k, v}, acc when is_map(v) ->
-        pathify_keys(v, [k | path_so_far], acc)
-
-      {k, v}, acc when is_list(k) ->
-        [{k, v} | acc]
-
-      {k, v}, acc ->
-        [{Enum.reverse([k | path_so_far]), v} | acc]
-    end)
-  end
-
-  defp load_config(table, plans, retry_count \\ 0)
-  defp load_config(_table, [], _), do: :ok
-  defp load_config(_table, _, 10), do: :error
-
-  defp load_config(table, [plan | rest], retry_count) do
-    case Vapor.Provider.load(plan) do
-      {:ok, configs} ->
-        configs
-        |> pathify_keys
-        |> Enum.each(fn k_v ->
-          :ets.insert(table, k_v)
-        end)
-
-        load_config(table, rest, 0)
-
-      {:error, _e} ->
-        load_config(table, [plan | rest], retry_count + 1)
-    end
   end
 end

--- a/lib/vapor/store/supervisor.ex
+++ b/lib/vapor/store/supervisor.ex
@@ -6,14 +6,24 @@ defmodule Vapor.Store.Supervisor do
 
   use Supervisor
 
+  alias Vapor.{
+    Store,
+    Watch
+  }
+
   def start_link(module, plans, opts) do
     name = Keyword.fetch!(opts, :name)
     Supervisor.start_link(__MODULE__, {module, plans}, name: :"#{name}_sup")
   end
 
+  def stop(name) do
+    Supervisor.stop(:"#{name}_sup")
+  end
+
   def init({module, plans}) do
     children = [
-      {Vapor.Store, {module, plans}}
+      {Vapor.Watch.Supervisor, [name: Watch.Supervisor.sup_name(module)]},
+      {Vapor.Store, {module, plans}},
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/vapor/store/supervisor.ex
+++ b/lib/vapor/store/supervisor.ex
@@ -22,8 +22,8 @@ defmodule Vapor.Store.Supervisor do
 
   def init({module, plans}) do
     children = [
-      {Vapor.Watch.Supervisor, [name: Watch.Supervisor.sup_name(module)]},
-      {Vapor.Store, {module, plans}},
+      {Watch.Supervisor, [name: Watch.Supervisor.sup_name(module)]},
+      {Store, {module, plans}},
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/vapor/watch.ex
+++ b/lib/vapor/watch.ex
@@ -27,7 +27,7 @@ defmodule Vapor.Watch do
     end
   end
 
-  defp schedule_refresh(%{opts: [refresh_interval: interval]}) do
-    Process.send_after(self(), :refresh, interval)
+  defp schedule_refresh(%{opts: opts}) do
+    Process.send_after(self(), :refresh, opts[:refresh_interval])
   end
 end

--- a/lib/vapor/watch.ex
+++ b/lib/vapor/watch.ex
@@ -1,0 +1,33 @@
+defmodule Vapor.Watch do
+  use GenServer
+
+  alias Vapor.{
+    Provider
+  }
+
+  def start_link(state) do
+    GenServer.start_link(__MODULE__, state)
+  end
+
+  def init(state) do
+    schedule_refresh(state.plan)
+    {:ok, state}
+  end
+
+  def handle_info(:refresh, %{plan: plan, store: store, layer: layer}=state) do
+    case Provider.load(plan.provider) do
+      {:ok, new_config} ->
+        :ok = Vapor.Store.update(store, layer, new_config)
+        schedule_refresh(plan)
+        {:noreply, state}
+
+      {:error, _} ->
+        schedule_refresh(plan)
+        {:noreply, %{state | error_count: state.error_count + 1}}
+    end
+  end
+
+  defp schedule_refresh(%{opts: [refresh_interval: interval]}) do
+    Process.send_after(self(), :refresh, interval)
+  end
+end

--- a/lib/vapor/watch/supervisor.ex
+++ b/lib/vapor/watch/supervisor.ex
@@ -1,0 +1,21 @@
+defmodule Vapor.Watch.Supervisor do
+  use DynamicSupervisor
+
+  def start_link(name: name) do
+    DynamicSupervisor.start_link(__MODULE__, :ok, name: name)
+  end
+
+  def sup_name(module) do
+    :"#{module}_watch_sup"
+  end
+
+  def start_child(module, state) do
+    spec = {Vapor.Watch, state}
+    DynamicSupervisor.start_child(sup_name(module), spec)
+  end
+
+  @impl true
+  def init(_arg) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end

--- a/test/vapor/config_test.exs
+++ b/test/vapor/config_test.exs
@@ -7,6 +7,10 @@ defmodule Vapor.ConfigTest do
     def start_link do
       Vapor.start_link(__MODULE__, Vapor.Config.default(), name: __MODULE__)
     end
+
+    def stop do
+      Vapor.stop(__MODULE__)
+    end
   end
 
   describe "get/2" do
@@ -24,6 +28,8 @@ defmodule Vapor.ConfigTest do
       assert TestConfig.get("float", as: :float) == {:ok, 3.2}
       assert TestConfig.get("true", as: :bool) == {:ok, true}
       assert TestConfig.get("false", as: :bool) == {:ok, false}
+
+      TestConfig.stop()
     end
 
     test "returns errors if conversions fail" do
@@ -46,6 +52,8 @@ defmodule Vapor.ConfigTest do
       assert_raise Vapor.ConversionError, fn ->
         TestConfig.get!("string", as: :bool)
       end
+
+      TestConfig.stop()
     end
 
     test "allows custom conversions" do
@@ -65,6 +73,8 @@ defmodule Vapor.ConfigTest do
       assert_raise Vapor.ConversionError, fn ->
         TestConfig.get!("string", as: fn "string" -> {:error, nil} end)
       end
+
+      TestConfig.stop()
     end
   end
 end

--- a/test/vapor/configuration_test.exs
+++ b/test/vapor/configuration_test.exs
@@ -1,0 +1,25 @@
+defmodule Vapor.ConfigurationTest do
+  use ExUnit.Case, async: true
+
+  alias Vapor.Configuration
+
+  describe "creating and updating a configuration" do
+    test "returns a list of commands to preform" do
+      {configuration, actions} =
+        %{
+          0 => %{foo: 0},
+          1 => %{foo: 1, bar: %{baz: 1}},
+        }
+        |> Configuration.new
+
+      assert actions == [{:upsert, [:bar, :baz], 1}, {:upsert, [:foo], 1}]
+
+      {new_config, actions} = Configuration.update(configuration, 0, %{foo: 2})
+      assert actions == []
+
+      {_config, actions} = Configuration.update(new_config, 1, %{foo: 3})
+      assert actions == [{:upsert, [:foo], 3}, {:delete, [:bar, :baz]}]
+    end
+  end
+end
+

--- a/test/vapor_test.exs
+++ b/test/vapor_test.exs
@@ -10,13 +10,17 @@ defmodule VaporTest do
     def start_link(config) do
       Vapor.start_link(__MODULE__, config, name: __MODULE__)
     end
+
+    def stop do
+      Vapor.stop(__MODULE__)
+    end
   end
 
   describe "configuration" do
     test "can be overriden manually" do
       config = Config.default()
 
-      TestConfig.start_link(config)
+      {:ok, _} = TestConfig.start_link(config)
 
       TestConfig.set("foo", "foo")
 
@@ -26,6 +30,8 @@ defmodule VaporTest do
       assert_raise Vapor.NotFoundError, fn ->
         TestConfig.get!("blank", as: :string)
       end
+
+      TestConfig.stop()
     end
 
     test "can pull in the environment" do
@@ -40,6 +46,8 @@ defmodule VaporTest do
 
       assert TestConfig.get!("foo", as: :string) == "foo"
       assert TestConfig.get!("bar", as: :string) == "bar"
+
+      TestConfig.stop()
     end
 
     test "can be stacked" do
@@ -56,6 +64,8 @@ defmodule VaporTest do
       assert TestConfig.get!("foo", as: :string) == "file foo"
       assert TestConfig.get!("bar", as: :string) == "env bar"
       assert TestConfig.get!("baz", as: :string) == "file baz"
+
+      TestConfig.stop()
     end
 
     test "path lists can be stacked" do
@@ -69,12 +79,44 @@ defmodule VaporTest do
       TestConfig.start_link(config)
 
       assert TestConfig.get!(["biz", "boz"], as: :string) == "file biz boz"
+
+      TestConfig.stop()
     end
 
     test "manual config always takes precedence" do
       config =
         Config.default()
-        |> Config.merge(Config.Env.with_prefix("APP"))
+        |> Config.watch(Config.Env.with_prefix("APP"), refresh_interval: 100)
+        |> Config.merge(Config.File.with_name("test/support/settings.json"))
+
+      System.put_env("APP_FOO", "env foo")
+      System.put_env("APP_BAR", "env bar")
+      System.put_env("APP_FIZ", "env fiz")
+
+      TestConfig.start_link(config)
+
+      TestConfig.set("foo", "manual foo")
+      TestConfig.set("bar", "manual bar")
+
+      System.put_env("APP_FOO", "foo take two")
+      System.put_env("APP_BAR", "bar take two")
+      System.put_env("APP_BAZ", "baz take two")
+      System.put_env("APP_FIZ", "fiz take two")
+
+      eventually(fn ->
+        assert TestConfig.get!("foo", as: :string) == "manual foo"
+        assert TestConfig.get!("bar", as: :string) == "manual bar"
+        assert TestConfig.get!("baz", as: :string) == "file baz"
+        assert TestConfig.get!("fiz", as: :string) == "fiz take two"
+      end)
+
+      TestConfig.stop()
+    end
+
+    test "sources can be watched for updates but still stack" do
+      config =
+        Config.default()
+        |> Config.watch(Config.Env.with_prefix("APP"), refresh_interval: 100)
         |> Config.merge(Config.File.with_name("test/support/settings.json"))
 
       System.put_env("APP_FOO", "env foo")
@@ -82,12 +124,19 @@ defmodule VaporTest do
 
       TestConfig.start_link(config)
 
-      TestConfig.set("foo", "manual foo")
-      TestConfig.set("bar", "manual bar")
-
-      assert TestConfig.get!("foo", as: :string) == "manual foo"
-      assert TestConfig.get!("bar", as: :string) == "manual bar"
+      assert TestConfig.get!("foo", as: :string) == "file foo"
+      assert TestConfig.get!("bar", as: :string) == "env bar"
       assert TestConfig.get!("baz", as: :string) == "file baz"
+
+      System.put_env("APP_FOO", "env foo second version")
+      System.put_env("APP_BAR", "env bar second version")
+
+      eventually(fn ->
+        assert TestConfig.get!("foo", as: :string) == "file foo"
+        assert TestConfig.get!("bar", as: :string) == "env bar second version"
+      end)
+
+      TestConfig.stop()
     end
 
     test "reads config from toml" do
@@ -95,11 +144,13 @@ defmodule VaporTest do
         Config.default()
         |> Config.merge(Config.File.with_name("test/support/settings.toml"))
 
-      TestConfig.start_link(config)
+      {:ok, _} = TestConfig.start_link(config)
 
       assert(TestConfig.get!("foo", as: :string) == "foo toml")
       assert(TestConfig.get!("bar", as: :string) == "bar toml")
       assert(TestConfig.get!(["biz", "boz"], as: :string) == "biz boz toml")
+
+      TestConfig.stop()
     end
 
     test "reads config from yaml" do
@@ -107,11 +158,25 @@ defmodule VaporTest do
         Config.default()
         |> Config.merge(Config.File.with_name("test/support/settings.yaml"))
 
-      TestConfig.start_link(config)
+      {:ok, _} = TestConfig.start_link(config)
 
       assert(TestConfig.get!("foo", as: :string) == "foo yaml")
       assert(TestConfig.get!("bar", as: :string) == "bar yaml")
       assert(TestConfig.get!(["biz", "boz"], as: :string) == "biz boz yaml")
+
+      TestConfig.stop()
     end
+  end
+
+  defp eventually(f, count \\ 0) do
+    f.()
+  rescue
+    e ->
+      if count > 5 do
+        raise e
+      else
+        :timer.sleep(50)
+        eventually(f, count + 1)
+      end
   end
 end

--- a/test/vapor_test.exs
+++ b/test/vapor_test.exs
@@ -175,7 +175,7 @@ defmodule VaporTest do
       if count > 5 do
         raise e
       else
-        :timer.sleep(50)
+        :timer.sleep(100)
         eventually(f, count + 1)
       end
   end


### PR DESCRIPTION
This PR builds on #32 to support watching config sources. We're now always ensuring that manual overrides are preserved even when a specific source we're watching is updated. There is still a fair bit of refactoring to do but I think this is going in a better direction then it was.