### PR TITLE
set alarm on watch failures

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -27,4 +27,4 @@ use Mix.Config
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-#     import_config "#{Mix.env}.exs"
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :sasl, sasl_error_logger: false

--- a/lib/vapor/watch.ex
+++ b/lib/vapor/watch.ex
@@ -10,6 +10,7 @@ defmodule Vapor.Watch do
   end
 
   def init(state) do
+    state = Map.merge(%{error_count: 0, current_alarm: false}, state)
     schedule_refresh(state.plan)
     {:ok, state}
   end
@@ -17,13 +18,26 @@ defmodule Vapor.Watch do
   def handle_info(:refresh, %{plan: plan, store: store, layer: layer}=state) do
     case Provider.load(plan.provider) do
       {:ok, new_config} ->
+        # We don't mind if we repeatedly spam the logs when there's a problem,
+        # but if everything is okay, we ought not attempt to clear an alarm
+        # that might not exist because the attempt with spam the logs.
+        if state.current_alarm do
+          :alarm_handler.clear_alarm({:vapor, {layer, plan.provider}})
+        end
         :ok = Vapor.Store.update(store, layer, new_config)
         schedule_refresh(plan)
-        {:noreply, state}
+        {:noreply, %{state | current_alarm: false}}
 
-      {:error, _} ->
+      {:error, _reason} ->
+        # We're intentionally NOT passing through the lower-level `reason` to
+        # the alarm_handler, since that information gets logged. The underlying
+        # configuration source could have sensitive information, like passwords,
+        # and we don't want those to end up in logs just because there was a
+        # temporary problem. By alarming with the layer and provider, we ought
+        # to give troubleshooters a head start in knowing where to investigate.
+        :alarm_handler.set_alarm({{:vapor, {layer, plan.provider}}, :redacted})
         schedule_refresh(plan)
-        {:noreply, %{state | error_count: state.error_count + 1}}
+        {:noreply, %{state | current_alarm: true, error_count: state.error_count + 1}}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Vapor.Mixfile do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:sasl, :logger]
     ]
   end
 


### PR DESCRIPTION
Prior to this commit we had no way of notifying other portions of the
system when we have a problem reading a configuration source. This
commit uses the `sasl` `alarm_handler` to set an alarm of the following
format `{:vapor, {plan_layer, plan_provider}}`. We also redact the
alarm `reason` because passing through lower-level `reason`s from their
error tuple could expose secrets to logging.

Closes #11