### PR TITLE
Marking dependencies as optional and with the correct envs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,9 +36,10 @@ defmodule Vapor.Mixfile do
       {:jason, "~> 1.1"},
       {:toml, "~> 0.3"},
       {:yaml_elixir, "~> 2.1"},
+
       # dev and test dependencies
-      {:credo, "~> 1.0"},
-      {:excoveralls, "~> 0.10.3"},
+      {:credo, "~> 1.0", only: [:dev]},
+      {:excoveralls, "~> 0.10.3", only: [:dev, :test]},
       {:dialyxir, "~> 1.0.0-rc.4", only: [:dev], runtime: false},
       {:ex_doc, "~> 0.19", only: :dev}
     ]


### PR DESCRIPTION
Before this PR we weren't marking a lot of our test and dev depencies with the
correct envs. We also hadn't marked our optional dependencies as optional.