### PR TITLE
Ignore comment lines in ".env" files

### DIFF
--- a/lib/vapor/provider/dotenv.ex
+++ b/lib/vapor/provider/dotenv.ex
@@ -39,11 +39,16 @@ defmodule Vapor.Provider.Dotenv do
     defp parse(contents) do
       contents
       |> String.split(~r/\n/, trim: true)
+      |> Enum.reject(&comment?/1)
       |> Enum.map(fn pair -> String.split(pair, "=") end)
       |> Enum.filter(&good_pair/1)
       |> Enum.map(fn [key, value] -> {String.trim(key), String.trim(value)} end)
       |> Enum.map(fn {key, value} -> {normalize(key), value} end)
       |> Enum.into(Map.new())
+    end
+
+    defp comment?(line) do
+      Regex.match?(~R/\A\s*#/, line)
     end
 
     defp good_pair(pair) do

--- a/test/vapor/provider/dotenv_test.exs
+++ b/test/vapor/provider/dotenv_test.exs
@@ -53,6 +53,7 @@ defmodule Vapor.Provider.DotenvTest do
       # This is a comment
       FOO=foo
       # BAR=bar
+        # BAZ=comment with indentation
       """
       File.write(".env", contents)
 

--- a/test/vapor/provider/dotenv_test.exs
+++ b/test/vapor/provider/dotenv_test.exs
@@ -47,6 +47,19 @@ defmodule Vapor.Provider.DotenvTest do
       {:ok, envs} = Vapor.Provider.load(plan)
       assert envs == %{["foo"] => "foo"}
     end
+
+    test "ignores comment lines" do
+      contents = """
+      # This is a comment
+      FOO=foo
+      # BAR=bar
+      """
+      File.write(".env", contents)
+
+      plan = Dotenv.default()
+      {:ok, envs} = Vapor.Provider.load(plan)
+      assert envs == %{["foo"] => "foo"}
+    end
   end
 
   describe "with_file/1" do


### PR DESCRIPTION
Make the `Dotenv` provider ignore lines that are commented out via `#`.

**Example** (as per the added test)

```
# This is a comment
FOO=foo
# BAR=bar
```

**Before**

This would create two key-value pairs:

1. `"FOO"` => `"foo"`
2. `"# BAR"` => `"bar"`

**Now**

Creates one pair: `"FOO"` => `"foo"`


Thanks for your ElixirConf talk by the way 🙂👋 