### PR TITLE
Say which env vars are missing in the error and expose that.

### DIFF
--- a/lib/vapor/store.ex
+++ b/lib/vapor/store.ex
@@ -44,8 +44,8 @@ defmodule Vapor.Store do
 
         {:ok, %{config: config, table: module}}
 
-      {:error, _} ->
-        {:stop, :could_not_load_config}
+      {:error, error} ->
+        {:stop, {:could_not_load_config, error}}
     end
   end
 


### PR DESCRIPTION
This replaces `{:error, :could_not_load_config}` with `{:error, {:could_not_load_config, "ENV vars not set: FOO, BAR"}}`, saves time trying to puzzle out which ones are really missing.