### PR TITLE
Implement handle_change

### DIFF
--- a/lib/vapor.ex
+++ b/lib/vapor.ex
@@ -48,6 +48,8 @@ defmodule Vapor do
   """
   @callback set(key :: key, value :: value) :: {:ok, value}
 
+  @callback handle_change :: (:ok)
+
   defmacro __using__(_opts) do
     quote do
       @behaviour Vapor
@@ -68,6 +70,7 @@ defmodule Vapor do
 
       def set(key, value) when is_list(key) do
         GenServer.call(__MODULE__, {:set, key, value})
+        handle_change()
       end
 
       def get(key, as: type) when is_binary(key) do

--- a/lib/vapor/store.ex
+++ b/lib/vapor/store.ex
@@ -21,6 +21,8 @@ defmodule Vapor.Store do
 
   def update(store, layer, new_config) do
     GenServer.call(store, {:update, layer, new_config})
+    store.handle_change
+
   end
 
   def init({module, plans}) do
@@ -52,7 +54,6 @@ defmodule Vapor.Store do
   def handle_call({:update, layer, new_values}, _, %{config: config}=state) do
     {new_config, actions} = Configuration.update(config, layer, new_values)
     process_actions(actions, state.table)
-
     {:reply, :ok, %{state | config: new_config}}
   end
 
@@ -64,6 +65,7 @@ defmodule Vapor.Store do
   end
 
   defp process_actions(actions, table) do
+    # IO.inspect(table, label: "Table: ")
     Enum.each(actions, fn action ->
       case action do
         {:upsert, key, value} ->


### PR DESCRIPTION
Added **handle_change** callback.
When a watch is on a file (in my case a json file) it automatically calls handle_change.
Tested with provider **file** (this is what I needed).