### PR TITLE
Rename Config to Plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ release and any kernel modules have started.
 
 Add vapor to your mix dependencies:
 
-```
+```elixir
 def deps do
   [
     {:vapor, "~> 0.2"},
@@ -41,16 +41,16 @@ end
 defmodule VaporExample.Config do
   use Vapor
 
-  alias Vapor.Config
-  alias Vapor.Provider.{File, Env}
+  alias Vapor.Plan
+  alias Vapor.Plan.{File, Env}
 
   def start_link(_args \\ []) do
-    config =
-      Config.default()
-      |> Config.merge(File.with_name("$HOME/.vapor/config.json"))
-      |> Config.merge(Env.with_prefix("APP"))
+    plan =
+      Plan.default()
+      |> Plan.merge(File.with_name("$HOME/.vapor/config.json"))
+      |> Plan.merge(Env.with_prefix("APP"))
 
-    Vapor.start_link(__MODULE__, config, name: __MODULE__)
+    Vapor.start_link(__MODULE__, plan, name: __MODULE__)
   end
 end
 
@@ -84,11 +84,11 @@ During the init process Vapor will block until the configuration is loaded. If a
 Vapor will apply configuration in the order that it is merged. In the example:
 
 ```elixir
-config =
-  Config.default()
-  |> Config.merge(Dotenv.default())
-  |> Config.merge(File.with_name("$HOME/.vapor/config.json"))
-  |> Config.merge(Env.with_prefix("APP"))
+plan =
+  Plan.default()
+  |> Plan.merge(Dotenv.default())
+  |> Plan.merge(File.with_name("$HOME/.vapor/config.json"))
+  |> Plan.merge(Env.with_prefix("APP"))
 ```
 
 Env will have the highest precedence, followed by File, and finally Dotenv.

--- a/lib/vapor/plan.ex
+++ b/lib/vapor/plan.ex
@@ -1,4 +1,4 @@
-defmodule Vapor.Config do
+defmodule Vapor.Plan do
   @moduledoc """
   This module provides conveniences for creating dynamic configuration layouts
   and overlays.

--- a/lib/vapor/plan/dotenv.ex
+++ b/lib/vapor/plan/dotenv.ex
@@ -1,4 +1,4 @@
-defmodule Vapor.Provider.Dotenv do
+defmodule Vapor.Plan.Dotenv do
   @moduledoc """
   The dotenv config provider will look for a `.env` file and load all of
   the values for that file. The values can be written like so:

--- a/lib/vapor/plan/env.ex
+++ b/lib/vapor/plan/env.ex
@@ -1,4 +1,4 @@
-defmodule Vapor.Provider.Env do
+defmodule Vapor.Plan.Env do
   @moduledoc """
   The Env config module provides support for pulling configuration values
   from the environment. It can do this by either specifying a prefix or by

--- a/lib/vapor/plan/file.ex
+++ b/lib/vapor/plan/file.ex
@@ -1,4 +1,4 @@
-defmodule Vapor.Provider.File do
+defmodule Vapor.Plan.File do
   @moduledoc """
   Module for loading supported file format configs
   Supported file formats: .json, .toml, .yaml

--- a/lib/vapor/store.ex
+++ b/lib/vapor/store.ex
@@ -9,8 +9,8 @@ defmodule Vapor.Store do
   use GenServer
 
   alias Vapor.{
-    Config,
     Configuration,
+    Plan,
     Provider,
     Watch,
   }
@@ -39,7 +39,7 @@ defmodule Vapor.Store do
         process_actions(actions, module)
 
         plans
-        |> Config.watches
+        |> Plan.watches
         |> Enum.each(fn {layer, plan} -> start_watch(layer, plan, module) end)
 
         {:ok, %{config: config, table: module}}

--- a/test/vapor/plan/dotenv_test.exs
+++ b/test/vapor/plan/dotenv_test.exs
@@ -1,7 +1,7 @@
-defmodule Vapor.Provider.DotenvTest do
+defmodule Vapor.Plan.DotenvTest do
   use ExUnit.Case, async: false
 
-  alias Vapor.Provider.Dotenv
+  alias Vapor.Plan.Dotenv
 
   describe "default/0" do
     setup do

--- a/test/vapor/plan/env_test.exs
+++ b/test/vapor/plan/env_test.exs
@@ -1,7 +1,7 @@
-defmodule Vapor.Provider.EnvTest do
+defmodule Vapor.Plan.EnvTest do
   use ExUnit.Case, async: false
 
-  alias Vapor.Provider.Env
+  alias Vapor.Plan.Env
 
   setup do
     System.delete_env("APP_FOO")

--- a/test/vapor_test.exs
+++ b/test/vapor_test.exs
@@ -2,15 +2,12 @@ defmodule VaporTest do
   use ExUnit.Case, async: false
   doctest Vapor
 
-  alias Vapor.{
-    Config,
-    Provider,
-  }
+  alias Vapor.Plan
 
   defmodule TestConfig do
     use Vapor
 
-    def start_link(config \\ Config.default()) do
+    def start_link(config \\ Plan.default()) do
       Vapor.start_link(__MODULE__, config, name: __MODULE__)
     end
 
@@ -21,7 +18,7 @@ defmodule VaporTest do
 
   describe "configuration" do
     test "can be overriden manually" do
-      config = Config.default()
+      config = Plan.default()
 
       {:ok, _} = TestConfig.start_link(config)
 
@@ -39,8 +36,8 @@ defmodule VaporTest do
 
     test "can pull in the environment" do
       config =
-        Config.default()
-        |> Config.merge(Provider.Env.with_prefix("APP"))
+        Plan.default()
+        |> Plan.merge(Plan.Env.with_prefix("APP"))
 
       System.put_env("APP_FOO", "foo")
       System.put_env("APP_BAR", "bar")
@@ -55,9 +52,9 @@ defmodule VaporTest do
 
     test "can be stacked" do
       config =
-        Config.default()
-        |> Config.merge(Provider.Env.with_prefix("APP"))
-        |> Config.merge(Provider.File.with_name("test/support/settings.json"))
+        Plan.default()
+        |> Plan.merge(Plan.Env.with_prefix("APP"))
+        |> Plan.merge(Plan.File.with_name("test/support/settings.json"))
 
       System.put_env("APP_FOO", "env foo")
       System.put_env("APP_BAR", "env bar")
@@ -73,9 +70,9 @@ defmodule VaporTest do
 
     test "path lists can be stacked" do
       config =
-        Config.default()
-        |> Config.merge(Provider.Env.with_prefix("APP"))
-        |> Config.merge(Provider.File.with_name("test/support/settings.json"))
+        Plan.default()
+        |> Plan.merge(Plan.Env.with_prefix("APP"))
+        |> Plan.merge(Plan.File.with_name("test/support/settings.json"))
 
       System.put_env("APP_BIZ_BOZ", "env biz boz")
 
@@ -88,9 +85,9 @@ defmodule VaporTest do
 
     test "manual config always takes precedence" do
       config =
-        Config.default()
-        |> Config.watch(Provider.Env.with_prefix("APP"), refresh_interval: 100)
-        |> Config.merge(Provider.File.with_name("test/support/settings.json"))
+        Plan.default()
+        |> Plan.watch(Plan.Env.with_prefix("APP"), refresh_interval: 100)
+        |> Plan.merge(Plan.File.with_name("test/support/settings.json"))
 
       System.put_env("APP_FOO", "env foo")
       System.put_env("APP_BAR", "env bar")
@@ -118,9 +115,9 @@ defmodule VaporTest do
 
     test "sources can be watched for updates but still stack" do
       config =
-        Config.default()
-        |> Config.watch(Provider.Env.with_prefix("APP"), refresh_interval: 100)
-        |> Config.merge(Provider.File.with_name("test/support/settings.json"))
+        Plan.default()
+        |> Plan.watch(Plan.Env.with_prefix("APP"), refresh_interval: 100)
+        |> Plan.merge(Plan.File.with_name("test/support/settings.json"))
 
       System.put_env("APP_FOO", "env foo")
       System.put_env("APP_BAR", "env bar")
@@ -144,8 +141,8 @@ defmodule VaporTest do
 
     test "reads config from toml" do
       config =
-        Config.default()
-        |> Config.merge(Provider.File.with_name("test/support/settings.toml"))
+        Plan.default()
+        |> Plan.merge(Plan.File.with_name("test/support/settings.toml"))
 
       {:ok, _} = TestConfig.start_link(config)
 
@@ -158,8 +155,8 @@ defmodule VaporTest do
 
     test "reads config from yaml" do
       config =
-        Config.default()
-        |> Config.merge(Provider.File.with_name("test/support/settings.yaml"))
+        Plan.default()
+        |> Plan.merge(Plan.File.with_name("test/support/settings.yaml"))
 
       {:ok, _} = TestConfig.start_link(config)
 


### PR DESCRIPTION
I'd like to create a distinction between a "config" which is a concrete realization of a merged and flattened configuration and a "plan".

The end goal is to provide a better solution to #8 and #22. Freeing up the name `Config` allows us to re-use the name for that use case.