### PR TITLE
Fix splitting env vars when value contains "="

### DIFF
--- a/lib/vapor/providers/dotenv.ex
+++ b/lib/vapor/providers/dotenv.ex
@@ -83,7 +83,7 @@ defmodule Vapor.Provider.Dotenv do
       contents
       |> String.split(~r/\n/, trim: true)
       |> Enum.reject(&comment?/1)
-      |> Enum.map(fn pair -> String.split(pair, "=") end)
+      |> Enum.map(fn pair -> String.split(pair, "=", parts: 2) end)
       |> Enum.filter(&good_pair/1)
       |> Enum.map(fn [key, value] -> {String.trim(key), String.trim(value)} end)
       |> Enum.map(fn {key, value} -> {key, value} end)

--- a/test/vapor/provider/dotenv_test.exs
+++ b/test/vapor/provider/dotenv_test.exs
@@ -44,7 +44,7 @@ defmodule Vapor.Provider.DotenvTest do
 
   test "ignores any malformed data" do
     contents = """
-    FOO=foo
+    FOO=foo=
     BAR
     =this is a baz
     """
@@ -52,7 +52,7 @@ defmodule Vapor.Provider.DotenvTest do
 
     plan = %Dotenv{}
     Vapor.Provider.load(plan)
-    assert System.get_env("FOO") == "foo"
+    assert System.get_env("FOO") == "foo="
     assert System.get_env("BAR") == nil
     assert System.get_env("BAZ") == nil
   end


### PR DESCRIPTION
In my experience it is common for autogenerated passwords and tokens to contain equals signs so they should be acceptable values.

I wasn't sure if you'd want this as a separate test or not so I put it under the existing "malformed data" test. I can updated if you'd like.

Thanks for the library!