### PR TITLE
Defaults and required

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Vapor
 
+<!-- MDOC !-->
+
 Loads dynamic configuration at runtime.
 
 ## Why Vapor?
@@ -12,18 +14,6 @@ providing an alternative to mix config for runtime configs. Specifically Vapor c
   * Find and load configuration from files (JSON, YAML, TOML).
   * Read configuration from environment variables.
   * `.env` file support for easy local development.
-
-## Installing
-
-Add vapor to your mix dependencies:
-
-```elixir
-def deps do
-  [
-    {:vapor, "~> 0.6"},
-  ]
-end
-```
 
 ## Example
 
@@ -100,6 +90,25 @@ config = Vapor.load(providers, translations)
 Config files can be read from a number of different file types including
 JSON, TOML, and YAML. Vapor determines which file format to use based on the file extension.
 
+### Options on bindings
+
+Bindings for `%Env{}` and `%File{}` providers support a number of options:
+
+* `:map` - Allows you to pass a "translation" function with the binding.
+* `:default` - If the value is not found then the default value will be returned instead. Defaults always skip the translations.
+* `:required` - Marks the binding a required or not required (defaults to true). If required values are missing, and there is no default present, then the provider will return an exception. If the binding is marked `required: false`, then the provider returns the key with a `nil` value.
+
+```elixir
+providers = [
+  %Env{
+    bindings: [
+      {:db_name, "DB_NAME"},
+      {:db_port, "DB_PORT", default: 4369, map: &String.to_integer/1},
+    ]
+  }
+]
+```
+
 ### Overriding application environment
 
 In some cases you may want to overwrite the keys in the application
@@ -143,6 +152,8 @@ defmodule MyApp.DatabaseProvider do
 end
 ```
 
+<!-- MDOC !-->
+
 ## Why does this exist?
 
 While its possible to use Elixir's release configuration for some use cases,
@@ -153,4 +164,17 @@ release configuration has some issues:
 * Its difficult to layer configuration from different sources.
 
 Vapor is designed to solve these problems.
+
+## Installing
+
+Add vapor to your mix dependencies:
+
+```elixir
+def deps do
+  [
+    {:vapor, "~> 0.6"},
+  ]
+end
+```
+
 

--- a/lib/vapor.ex
+++ b/lib/vapor.ex
@@ -1,7 +1,8 @@
 defmodule Vapor do
-  @moduledoc """
-  Vapor provides mechanisms for loading runtime configuration in your system.
-  """
+  @moduledoc "README.md"
+             |> File.read!()
+             |> String.split("<!-- MDOC !-->")
+             |> Enum.fetch!(1)
 
   alias Vapor.Provider
   alias Vapor.LoadError

--- a/lib/vapor/providers/env.ex
+++ b/lib/vapor/providers/env.ex
@@ -10,30 +10,59 @@ defmodule Vapor.Provider.Env do
 
   defstruct bindings: [], required: true
 
-  @type bindings :: Keyword.t(String.t())
-
   defimpl Vapor.Provider do
     def load(%{bindings: bindings, required: required}) do
       envs = System.get_env()
 
       bound_envs =
         bindings
-        |> Map.new(fn {key, env} -> {key, Map.get(envs, env, :missing)} end)
+        |> Enum.map(&normalize_binding/1)
+        |> Enum.map(&create_binding(&1, envs))
+        |> Enum.into(%{})
 
       missing =
         bound_envs
-        |> Enum.filter(fn {_, env} -> env == :missing end)
-        |> Enum.map(fn {k, :missing} -> Keyword.get(bindings, k) end)
+        |> Enum.filter(fn {_, data} -> data.val == :missing end)
+        |> Enum.map(fn {_k, data} -> data.env end)
 
       if required && Enum.any?(missing) do
         {:error, "ENV vars not set: #{Enum.join(missing, ", ")}"}
       else
         envs =
           bound_envs
-          |> Enum.reject(fn {_, env} -> env == :missing end)
+          |> Enum.reject(fn {_, data} -> data.val == :missing end)
+          |> Enum.map(fn {name, data} -> {name, data.val} end)
           |> Enum.into(%{})
+
         {:ok, envs}
       end
+    end
+
+    defp normalize_binding({name, variable}) do
+      {name, %{val: nil, env: variable, opts: default_opts()}}
+    end
+    defp normalize_binding({name, variable, opts}) do
+      {name, %{val: nil, env: variable, opts: Keyword.merge(default_opts(), opts)}}
+    end
+
+    defp create_binding({name, data}, envs) do
+      case envs[data.env] do
+        nil ->
+          val = data.opts[:default] || (if data.opts[:required], do: :missing, else: nil)
+          {name, %{data | val: val}}
+
+        env ->
+          # Call the map function which defaults to identity
+          {name, %{data | val: data.opts[:map].(env)}}
+      end
+    end
+
+    defp default_opts do
+      [
+        map: fn x -> x end,
+        default: nil,
+        required: true,
+      ]
     end
   end
 end

--- a/test/vapor/provider/env_test.exs
+++ b/test/vapor/provider/env_test.exs
@@ -45,4 +45,39 @@ defmodule Vapor.Provider.EnvTest do
     }
     assert {:ok, %{foo: "FOO VALUE"}} == Provider.load(provider)
   end
+
+  test "translations can be provided inline" do
+    System.put_env("FOO", "3")
+
+    provider = %Env{
+      bindings: [
+        {:foo, "FOO", map: &String.to_integer/1},
+      ]
+    }
+    assert {:ok, %{foo: 3}} == Provider.load(provider)
+  end
+
+  test "can specify default values" do
+    System.put_env("FOO", "3")
+
+    provider = %Env{
+      bindings: [
+        {:foo, "FOO", map: &String.to_integer/1},
+        {:bar, "BAR", default: 1337},
+      ]
+    }
+    assert {:ok, %{foo: 3, bar: 1337}} = Provider.load(provider)
+  end
+
+  test "can mark a value as non-required" do
+    System.put_env("FOO", "3")
+
+    provider = %Env{
+      bindings: [
+        {:foo, "FOO", map: &String.to_integer/1},
+        {:bar, "BAR", required: false},
+      ]
+    }
+    assert {:ok, %{foo: 3, bar: nil}} = Provider.load(provider)
+  end
 end

--- a/test/vapor/provider/file_test.exs
+++ b/test/vapor/provider/file_test.exs
@@ -44,4 +44,36 @@ defmodule Vapor.Provider.FileTest do
     assert {:error, error} = Provider.load(provider)
     assert error == "Missing keys in file: bar, boz"
   end
+
+  test "translations can be provided inline" do
+    provider = %File{
+      path: "test/support/settings.json",
+      bindings: [
+        {:foo, "foo", map: fn "file foo" -> 1337 end},
+      ]
+    }
+    assert {:ok, %{foo: 1337}} == Provider.load(provider)
+  end
+
+  test "can specify default values" do
+    provider = %File{
+      path: "test/support/settings.json",
+      bindings: [
+        {:foo, "foo"},
+        {:bar, ["some", "key"], default: 1337},
+      ]
+    }
+    assert {:ok, %{foo: "file foo", bar: 1337}} = Provider.load(provider)
+  end
+
+  test "can mark a value as non-required" do
+    provider = %File{
+      path: "test/support/settings.json",
+      bindings: [
+        {:foo, "foo"},
+        {:bar, ["some", "key"], required: false},
+      ]
+    }
+    assert {:ok, %{foo: "file foo", bar: nil}} = Provider.load(provider)
+  end
 end


### PR DESCRIPTION
After this PR, env and file providers will allow users to pass options for each "binding". The initial options are `map`, `required`, and `default`. `map` allows users to pass a translation (a mapping function) alongside a binding. If a binding is marked as `required: false` then vapor will return the key with `nil` as the value. If a binding has a `default` and the value specified in the binding is missing then the default is provided. Defaults should always skip the `map` function.

## Example

```elixir
providers = [
  %Env{
    bindings: [
      {:foo, "FOO", default: 1337, map: &String.to_integer/1},
    ]
  }
]
```