### PR TITLE
Add group providers

### DIFF
--- a/lib/vapor/loader.ex
+++ b/lib/vapor/loader.ex
@@ -1,0 +1,34 @@
+defmodule Vapor.Loader do
+  @moduledoc false
+  # This module provides a unified way to load a series of providers and merge
+  # them into a single result.
+  alias Vapor.Provider
+  alias Vapor.LoadError
+
+  def load(provider) when not is_list(provider) do
+    load([provider])
+  end
+  def load(providers) do
+    results =
+      providers
+      |> Enum.map(& Provider.load(&1))
+
+    errors =
+      results
+      |> Enum.filter(& match?({:error, _}, &1))
+      |> Enum.map(fn {:error, error} -> error end)
+
+    if Enum.any?(errors) do
+      error = LoadError.exception(errors)
+      {:error, error}
+    else
+      config =
+        results
+        |> Enum.map(fn {:ok, v} -> v end)
+        |> Enum.reduce(%{}, fn layer, config -> Map.merge(config, layer) end)
+        |> Enum.into(%{})
+
+      {:ok, config}
+    end
+  end
+end

--- a/lib/vapor/providers/group.ex
+++ b/lib/vapor/providers/group.ex
@@ -1,0 +1,35 @@
+defmodule Vapor.Provider.Group do
+  @moduledoc """
+  Allows users to group together bits of configuration. This allows users to
+  avoid duplication and avoids conflicts in common names such as "port" and
+  "host".
+
+  ## Example
+
+  ```elixir
+  providers = [
+    %Group{
+      name: :primary_db,
+      providers: [
+        %Env{bindings: [port: "PRIMARY_DB_PORT", host: "PRIMARY_DB_HOST"]},
+      ]
+    },
+    %Group{
+      name: :redis,
+      providers: [
+        %Env{bindings: [port: "REDIS_PORT", host: "REDIS_HOST"]},
+      ]
+    },
+  ]
+  ```
+  """
+  defstruct providers: [], name: nil
+
+  defimpl Vapor.Provider do
+    def load(%{providers: providers, name: name}) do
+      with {:ok, config} <- Vapor.Loader.load(providers) do
+        {:ok, Map.put(Map.new(), name, Keyword.new(config))}
+      end
+    end
+  end
+end

--- a/test/vapor/provider/group_test.exs
+++ b/test/vapor/provider/group_test.exs
@@ -1,0 +1,46 @@
+defmodule Vapor.Provider.GroupTest do
+  use ExUnit.Case, async: false
+
+  alias Vapor.Provider.{Group, Env}
+
+  setup do
+    System.delete_env("DB_HOST")
+
+    :ok
+  end
+
+  test "groups return a grouped set of configs" do
+    System.put_env("DB_HOST", "4369")
+
+    provider = %Group{name: :primary_db, providers: [
+      %Env{bindings: [
+        {:host, "DB_HOST", map: &String.to_integer/1},
+      ]},
+    ]}
+
+    assert Vapor.load!(provider) == %{primary_db: [host: 4369]}
+  end
+
+  # TODO - This test is not here to enforce this behaviour. In fact this really
+  # isn't what we want. The test serves to specify the existing
+  # semantics. We should change this eventually.
+  test "groups with matching names are shallow merged" do
+    System.put_env("DB_PORT", "4369")
+    System.put_env("DB_HOST", "postgres")
+
+    providers = [
+      %Group{name: :primary_db, providers: [
+        %Env{bindings: [
+          host: "DB_HOST",
+        ]},
+      ]},
+      %Group{name: :primary_db, providers: [
+        %Env{bindings: [
+          {:port, "DB_PORT", map: &String.to_integer/1},
+        ]},
+      ]},
+    ]
+
+    assert Vapor.load!(providers) == %{primary_db: [port: 4369]}
+  end
+end

--- a/test/vapor_test.exs
+++ b/test/vapor_test.exs
@@ -80,6 +80,10 @@ defmodule VaporTest do
       assert {:error, error} = Vapor.load(providers)
       assert match?(%Vapor.LoadError{}, error)
     end
+
+    test "allows a single provider" do
+      assert {:ok, _} = Vapor.load(%Env{})
+    end
   end
 
   describe "load!/2" do


### PR DESCRIPTION
This PR introduces "group" functionality as a provider. This allows users to name sets of configuration which is useful to avoid duplication and avoids conflicts in common names such as "port" and "host.

## Example

```elixir
providers = [
  %Group{
    name: :primary_db,
    providers: [
      %Env{bindings: [port: "PRIMARY_DB_PORT", host: "PRIMARY_DB_HOST"]},
    ]
  },
  %Group{
    name: :redis,
    providers: [
      %Env{bindings: [port: "REDIS_PORT", host: "REDIS_HOST"]},
    ]
  },
]
```