### PR TITLE
Vapor.Provider.Group does not cumulate Vapor.LoadError

### DIFF
--- a/lib/vapor/loader.ex
+++ b/lib/vapor/loader.ex
@@ -16,7 +16,7 @@ defmodule Vapor.Loader do
     errors =
       results
       |> Enum.filter(& match?({:error, _}, &1))
-      |> Enum.map(fn {:error, error} -> error end)
+      |> Enum.map(& normalize_error/1)
 
     if Enum.any?(errors) do
       error = LoadError.exception(errors)
@@ -30,5 +30,13 @@ defmodule Vapor.Loader do
 
       {:ok, config}
     end
+  end
+
+  defp normalize_error({:error, %_{message: message}}) do
+    message
+  end
+
+  defp normalize_error({:error, error}) do
+    error
   end
 end

--- a/test/vapor/provider/group_test.exs
+++ b/test/vapor/provider/group_test.exs
@@ -5,6 +5,7 @@ defmodule Vapor.Provider.GroupTest do
 
   setup do
     System.delete_env("DB_HOST")
+    System.delete_env("DB_PORT")
 
     :ok
   end
@@ -42,5 +43,17 @@ defmodule Vapor.Provider.GroupTest do
     ]
 
     assert Vapor.load!(providers) == %{primary_db: [port: 4369]}
+  end
+
+  test "groups returns error if config is missing" do
+    provider =
+      %Group{name: :primary_db, providers: [
+        %Env{bindings: [
+          {:port, "DB_PORT", map: &String.to_integer/1},
+        ]},
+      ]}
+
+    assert {:error, error} = Vapor.load(provider)
+    assert match?(%Vapor.LoadError{}, error)
   end
 end


### PR DESCRIPTION
Hey. 

Encountered a bug with `Vapor.Provider.Group` and missing config variables. 

```
** (Protocol.UndefinedError) protocol String.Chars not implemented for %Vapor.LoadError{message: "There were errors loading configuration:\nENV vars not set: DB_PORT\n"} of type Vapor.LoadError (a struct). This protocol is implemented for the following type(s): Float, NaiveDateTime, Integer, Time, Atom, Version, DateTime, BitString, Version.Requirement, URI, Date, List
```

- Add a corresponding test case
- Add a possible solution (you might have a better solution)