### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ config = Vapor.load!(providers)
 Application.put_env(:my_app, MyApp.Repo, [
   database: config[:database],
   username: config[:database_user],
-  password: config[:database_pasword],
+  password: config[:database_password],
   hostname: config[:database_host],
   port: config[:database_port],
 ])


### PR DESCRIPTION
I just copy/pasted the example code and found my code unable to connect to the DB because the password was missing.
`config[:database_pasword]` obviously should be `config[:database_password]`