### PR TITLE
Add plan behaviour

### DIFF
--- a/lib/vapor/loader.ex
+++ b/lib/vapor/loader.ex
@@ -10,6 +10,7 @@ defmodule Vapor.Loader do
   def load(providers) do
     results =
       providers
+      |> Enum.flat_map(&expand_modules/1)
       |> Enum.map(& Provider.load(&1))
 
     errors =
@@ -33,4 +34,14 @@ defmodule Vapor.Loader do
   defp normalize_error({:error, error}) do
     error
   end
+
+  defp expand_modules(module) when is_atom(module) do
+    if function_exported?(module, :config_plan, 0) do
+      List.wrap(module.config_plan())
+    else
+      raise ArgumentError, "#{module} does not export `config_plan/0`"
+    end
+  end
+
+  defp expand_modules(foo), do: [foo]
 end

--- a/lib/vapor/plan.ex
+++ b/lib/vapor/plan.ex
@@ -1,0 +1,8 @@
+defmodule Vapor.Plan do
+  @moduledoc """
+  This module provides a behaviour that allows other modules to define their own configuration plans. This allows modules to define their configuration on the module which can later
+  be loaded using `Vapor.load/1`.
+  """
+
+  @callback config_plan :: list() | map()
+end

--- a/test/vapor/plan_test.exs
+++ b/test/vapor/plan_test.exs
@@ -1,0 +1,76 @@
+defmodule Vapor.PlanTest do
+  use ExUnit.Case, async: true
+
+  alias Vapor.Provider.Env
+
+  setup do
+    System.delete_env("FOO")
+    System.delete_env("BAR")
+
+    :ok
+  end
+
+  defmodule Plan do
+    @behaviour Vapor.Plan
+
+    @impl true
+    def config_plan do
+      [
+        %Env{
+          bindings: [
+            foo: "FOO"
+          ]
+        }
+      ]
+    end
+  end
+
+  defmodule SimplePlan do
+    @behaviour Vapor.Plan
+
+    def config_plan do
+      %Env{
+        bindings: [
+          foo: "FOO"
+        ]
+      }
+    end
+  end
+
+  test "plan modules can be loaded" do
+    System.put_env("FOO", "FOO VALUE")
+    System.put_env("BAR", "BAR VALUE")
+
+    config = Vapor.load!(Plan)
+    assert config.foo == "FOO VALUE"
+  end
+
+  test "plan modules can return a single provider" do
+    System.put_env("FOO", "FOO VALUE")
+
+    config = Vapor.load!(SimplePlan)
+    assert config.foo == "FOO VALUE"
+  end
+
+  test "plan modules can be layered with other providers" do
+    System.put_env("FOO", "FOO VALUE")
+    System.put_env("BAR", "BAR VALUE")
+
+    providers = [
+      Plan,
+      %Env{
+        bindings: [bar: "BAR"]
+      },
+    ]
+
+    config = Vapor.load!(providers)
+    assert config.foo == "FOO VALUE"
+    assert config.bar == "BAR VALUE"
+  end
+
+  test "modules that don't export config_plan/0 raise" do
+    assert_raise ArgumentError, fn ->
+      Vapor.load!(UnknownPlan)
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces a new behaviour. This behaviour allows modules to define their own configuration requirements like so:

```elixir
defmodule MyModule do
  def config_plan do
    [
      %Env{},
    ]
  end
end

Vapor.load!([
  %Dotenv{},
  MyModule,
])
```

This is based on a pattern that we're already using at B/R. It also provides a path for adding a more ergonomic DSL for building configuration plans.